### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Atlassian Companion/Atlassian Companion.filewave.recipe
+++ b/Atlassian Companion/Atlassian Companion.filewave.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Atlassian Companion</string>
      		<key>fw_destination_root</key>
-    		<string>/Applications/%NAME%.app</string>
+    		<string>/Applications/Atlassian Companion.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -37,7 +37,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Atlassian Companion.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -54,7 +54,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Atlassian Companion.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Franz/Franz.filewave.recipe
+++ b/Franz/Franz.filewave.recipe
@@ -17,7 +17,7 @@
       		<key>fw_app_bundle_id</key>
        		<string>com.meetfranz.franz</string>
      		<key>fw_destination_root</key>
-    		<string>/Applications/%NAME%.app</string>
+    		<string>/Applications/Franz.app</string>
 		</dict>
 	<key>Process</key>
 		<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Franz.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Franz.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/FreeCAD/FreeCAD.filewave.recipe
+++ b/FreeCAD/FreeCAD.filewave.recipe
@@ -17,7 +17,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.andredb90.filewave.FreeCAD</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/FreeCAD.app</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/FreeCAD.app</string>
 				<key>source_path</key>
 				<string>%pathname%/*.app</string>
 			</dict>
@@ -58,7 +58,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/FreeCAD.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Wrike/Wrike.filewave.recipe
+++ b/Wrike/Wrike.filewave.recipe
@@ -17,7 +17,7 @@
        		<key>fw_app_bundle_id</key>
     		<string>com.wrike.name</string>
      		<key>fw_destination_root</key>
-    		<string>/Applications/%NAME%.app</string>
+    		<string>/Applications/Wrike.app</string>
 		</dict>
  	<key>Process</key>
 	<array>
@@ -39,7 +39,7 @@
                         <key>Arguments</key>
                         <dict>
                                 <key>destination_path</key>
-                                <string>%pkgroot%/%NAME%.app</string>
+                                <string>%pkgroot%/Wrike.app</string>
                                 <key>source_path</key>
                                 <string>%pathname%/*.app</string>
                         </dict>
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Wrike.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -69,7 +69,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/Wrike.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.