### PR TITLE
Deprecate Swisscom Business Communication recipes

### DIFF
--- a/Swisscom Business Communication/BusinessCommunication.download.recipe
+++ b/Swisscom Business Communication/BusinessCommunication.download.recipe
@@ -14,7 +14,7 @@
 		<string>Business Communication</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Swisscom Business Communication/BusinessCommunication.download.recipe
+++ b/Swisscom Business Communication/BusinessCommunication.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Swisscom Business Communication is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>


### PR DESCRIPTION
The Swisscom Business Communication product seems not to be available for download any longer. This PR deprecates the Swisscom Business Communication recipe family.