### PR TITLE
Use zentral-recipes swiftDialog.download as parent

### DIFF
--- a/swiftDialog/swiftDialog.download.recipe
+++ b/swiftDialog/swiftDialog.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the swiftDialog recipes in the zentral-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>github_repo</key>

--- a/swiftDialog/swiftDialog.filewave.recipe
+++ b/swiftDialog/swiftDialog.filewave.recipe
@@ -16,7 +16,7 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.andredb90.download.swiftDialog</string>
+    <string>com.github.zentralpro.download.swiftDialog</string>
     <key>Process</key>
     <array>
   		<dict>


### PR DESCRIPTION
This changes the parent of the swiftDialog recipes in this repo to use the download recipe in zentral-recipes, which was created before the equivalent download recipe in this repo but is otherwise the same.

This consolidation will help simplify search results and lower maintenance effort.

