### PR TITLE
Fix app name: renamed from 'Ledger Live.app' to 'Ledger Wallet.app'

### DIFF
--- a/Ledger/LedgerLive.download.recipe
+++ b/Ledger/LedgerLive.download.recipe
@@ -34,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Ledger Live.app</string>
+				<string>%pathname%/Ledger Wallet.app</string>
 				<key>requirement</key>
 				<string>identifier "com.ledger.live" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X6LFS5BQKN</string>
 			</dict>
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Ledger Live.app/Contents/Info.plist</string>
+				<string>%pathname%/Ledger Wallet.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Ledger renamed the app bundle inside their DMG from Ledger Live.app to Ledger Wallet.app. This caused AutoPkg to fail with a glob error when trying to locate the app for code signature verification and versioning.