### PR TITLE
Fix SecureSafe pkg payload path

### DIFF
--- a/SecureSafe/SecureSafe.download.recipe
+++ b/SecureSafe/SecureSafe.download.recipe
@@ -71,7 +71,7 @@
 			<key>destination_path</key>
 			<string>%RECIPE_CACHE_DIR%/expanded</string>
 			<key>pkg_payload_path</key>
-			<string>%RECIPE_CACHE_DIR%/unpacked/Core.pkg/payload</string>
+			<string>%RECIPE_CACHE_DIR%/unpacked/com.dswiss.secure-safe-files.pkg/payload</string>
 			<key>purge_destination</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
## Summary

- Updates `pkg_payload_path` in `SecureSafe.download.recipe` from `Core.pkg/payload` to `com.dswiss.secure-safe-files.pkg/payload`
- The inner package bundle identifier changed in a recent SecureSafe release, causing `PkgPayloadUnpacker` to fail

## Verification

Tested locally with `autopkg run -v SecureSafe.download.recipe` — successfully downloaded and verified SecureSafe Files **1.1.0** (arm64 pkg):

```
URLTextSearcher: Found matching text (match): //app.securesafe.com/app/download/SecureSafe-Files-1.1.0-arm64.pkg
URLDownloader: Downloaded .../downloads/SecureSafe-Files-1.1.0-arm64.pkg
CodeSignatureVerifier: Signature is valid
  Developer ID Installer: DSwiss Ltd. (U8DL7XVP69) — expires 2029-06-26
PkgPayloadUnpacker: Unpacked .../unpacked/com.dswiss.secure-safe-files.pkg/payload
FileFinder: Found SecureSafe Files.app/Contents/Info.plist
Versioner: Found version 1.1.0
```

Note: the companion Munki recipe changes were merged separately in autopkg/dataJAR-recipes#594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)